### PR TITLE
Adding host parameter to Solr startup so that the fabric-defined hostnames are used

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -299,7 +299,7 @@ def solr_clusterstate():
 @roles('solr')
 def upstart_solr():
     """ Write an Upstart script for Solr. """
-    context = { "user": env.user, "group": env.user, "path": os.path.join(env.solr_dir, "example"),
+    context = { "host": env.host, "user": env.user, "group": env.user, "path": os.path.join(env.solr_dir, "example"),
     "num_shards": env.num_shards, "zookeeper_hostports": zookeeper_hostports() }
     upload_template(filename='solr-upstart.conf', destination='/etc/init/{0}.conf'.format(env.solr_service),
         template_dir=TEMPLATES, context=context, use_sudo=True, use_jinja=True)

--- a/templates/solr-upstart.conf
+++ b/templates/solr-upstart.conf
@@ -19,6 +19,6 @@ setgid {{ group }}
 
 script
     cd {{ path }}
-    exec java -DzkHost={{ zookeeper_hostports }} -DnumShards={{ num_shards }} -jar start.jar
+    exec java -Dhost={{ host }} -DzkHost={{ zookeeper_hostports }} -DnumShards={{ num_shards }} -jar start.jar
 end script
 


### PR DESCRIPTION
On the main Ubuntu AMI on EC2, Solr will use the internal IP of the host in the cloud graphs in the admin UI. This changes upstart to send the -Dhost parameter, and that value is set by Fabric in the roledefs so that the host name is going to be resolvable by the machine running Fabric.
