### PR TITLE
Multicore support and configurable solr port

### DIFF
--- a/solr-fabric-guide.md
+++ b/solr-fabric-guide.md
@@ -171,6 +171,17 @@ You can inspect the Solr Admin user interface on e.g.
 (adjust for your hostname)
 
 
+Runing Multicore Mode
+---------------------
+
+Setup solr using `fab install_solr` and then
+
+1. `fab stop_solr`
+2. Update fabfile.py with `env.solr_home='multicore'`
+3. `fab bootstrap_multicore_solrcloud`
+4. `fab start_solr`
+
+
 Loading data
 ------------
 

--- a/templates/solr-upstart.conf
+++ b/templates/solr-upstart.conf
@@ -19,6 +19,6 @@ setgid {{ group }}
 
 script
     cd {{ path }}
-    exec java -Dhost={{ host }} -DzkHost={{ zookeeper_hostports }} -DnumShards={{ num_shards }} -jar start.jar
+    exec java -Dhost={{ host }} -DzkHost={{ zookeeper_hostports }} -Dsolr.solr.home={{ solr_home }} -DnumShards={{ num_shards }} -jar start.jar
 end script
 


### PR DESCRIPTION
Made 4 changes:
1. Running multicore was not possible. So I have made it configurable. "solr" is setup by default, but if someone wants to run solr in multicore mode, can do so.
2. Made port configurable via env.solr_port
3. Fixed solr download URL
4. Updated solr-fabric-guide.md

Thanks!
